### PR TITLE
Readme: fix installation line

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It's a simplified version of a similar GTK based tool [tider](https://github.com
 
 ## Installation
 ```
-go get github.com/naspeh/timefor
+go install github.com/naspeh/timefor@latest
 ```
 
 Or just download [the binary.](https://github.com/naspeh/timefor/raw/master/timefor)


### PR DESCRIPTION
Since version [1.18](https://tip.golang.org/doc/go1.18) 

> go: go.mod file not found in current directory or any parent directory.
> 	`go get` is no longer supported outside a module.
> 	To build and install a command, use `go install` with a version,
> 	like `go install example.com/cmd@latest`
> 	For more information, see https://golang.org/doc/go-get-install-deprecation
> 	or run`'go help get` or `go help install`.

                                                                                     